### PR TITLE
feat(#33): disable selection for unavailable stage templates

### DIFF
--- a/internal/github/bracket_template_client.go
+++ b/internal/github/bracket_template_client.go
@@ -30,6 +30,21 @@ func NewBracketTemplateClient(httpClient *http.Client) *BracketTemplateClient {
 	}
 }
 
+func (c *BracketTemplateClient) GetAvailableStageTemplate(ctx context.Context) ([]string, error) {
+	var bracketTypeByStageID map[string]string
+	bracketTypeByStageID, err := c.getBracketTemplateMapper(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(bracketTypeByStageID))
+	for k := range bracketTypeByStageID {
+		keys = append(keys, k)
+	}
+
+	return keys, nil
+}
+
 // GetTemplateByStageID fetches the bracket template associated with the given stage id.
 //
 // An error is returned if no bracket template is associated with the stage id or

--- a/internal/rift/bracket_template_loader.go
+++ b/internal/rift/bracket_template_loader.go
@@ -24,6 +24,7 @@ type BracketTemplateClient interface {
 	// GetTemplateByStageID shoulds return the BracketTemplate
 	// associated to the given stage id.
 	GetTemplateByStageID(ctx context.Context, stageID string) (BracketTemplate, error)
+	GetAvailableStageTemplate(ctx context.Context) ([]string, error)
 }
 
 // BracketTemplateLoader handles loading bracket templates from multiple sources.
@@ -44,6 +45,16 @@ func NewBracketTemplateLoader(
 		cache:  cache,
 		logger: logger.WithGroup("bracketTemplateLoader"),
 	}
+}
+
+// ListAvailableStageIDs returns the list of known stageIDs.
+func (l *BracketTemplateLoader) ListAvailableStageIDs(ctx context.Context) ([]string, error) {
+	stageIDs, err := l.client.GetAvailableStageTemplate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return stageIDs, nil
 }
 
 // Load tries to load the bracket template associated to the given stage ID

--- a/internal/rift/bracket_template_test.go
+++ b/internal/rift/bracket_template_test.go
@@ -148,13 +148,15 @@ var chuninExamsBracketTemplate = rift.BracketTemplate{
 var errAPINotFound = errors.New("not found")
 
 type stubBracketTemplateAPIClient struct {
-	template rift.BracketTemplate
-	err      error
+	template        rift.BracketTemplate
+	availableStages []string
+	err             error
 }
 
 func newStubBracketTemplateAPIClient() *stubBracketTemplateAPIClient {
 	return &stubBracketTemplateAPIClient{
-		template: chuninExamsBracketTemplate,
+		template:        chuninExamsBracketTemplate,
+		availableStages: []string{"1", "2"},
 	}
 }
 
@@ -170,4 +172,13 @@ func (api *stubBracketTemplateAPIClient) GetTemplateByStageID(
 		return rift.BracketTemplate{}, api.err
 	}
 	return api.template, nil
+}
+
+func (api *stubBracketTemplateAPIClient) GetAvailableStageTemplate(
+	_ context.Context,
+) ([]string, error) {
+	if api.err != nil {
+		return nil, api.err
+	}
+	return api.availableStages, nil
 }

--- a/internal/ui/colors.go
+++ b/internal/ui/colors.go
@@ -32,6 +32,7 @@ var (
 	textPrimaryColor         = lipgloss.AdaptiveColor{Light: almostBlack, Dark: lightGrey}
 	textSecondaryColor       = lipgloss.AdaptiveColor{Light: sonicSilver, Dark: grey}
 	textDimmedSecondaryColor = lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: dimGrey}
+	textDisabledColor        = lipgloss.AdaptiveColor{Light: "#555156", Dark: "#505050"}
 	textTitleColor           = lipgloss.AdaptiveColor{Light: black, Dark: white}
 
 	borderPrimaryColor   = lipgloss.AdaptiveColor{Light: eerieBlack, Dark: white}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -67,6 +67,7 @@ type LoLEsportsLoader interface {
 
 // BracketTemplateLoader loads bracket templates.
 type BracketTemplateLoader interface {
+	ListAvailableStageIDs(ctx context.Context) ([]string, error)
 	// Load returns the [rift.BracketTemplate] associated with stageID.
 	Load(ctx context.Context, stageID string) (rift.BracketTemplate, error)
 }

--- a/internal/ui/stages.go
+++ b/internal/ui/stages.go
@@ -1,11 +1,16 @@
 package ui
 
 import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/matthieugusmini/go-lolesports"
 )
 
@@ -19,37 +24,35 @@ const (
 type stageItem struct {
 	name      string
 	stageType stageType
+	disabled  bool
 }
 
 func (i stageItem) Title() string { return i.name }
 
 func (i stageItem) Description() string { return string(i.stageType) }
 
+func (i stageItem) IsDisabled() bool { return i.disabled }
+
 func (i stageItem) FilterValue() string { return i.name }
 
-func newStageOptionsList(stages []lolesports.Stage, width, height int) list.Model {
+func newStageOptionsList(
+	stages []lolesports.Stage,
+	availableStages []string,
+	width, height int,
+) list.Model {
 	stageItems := make([]list.Item, len(stages))
 	for i, stage := range stages {
 		item := stageItem{
 			name:      stage.Name,
 			stageType: getStageType(stage),
+			disabled:  isStageAvailable(stage, availableStages),
 		}
 		stageItems[i] = item
 	}
 
-	delegate := list.NewDefaultDelegate()
-	delegate.Styles.SelectedTitle = delegate.Styles.SelectedTitle.
-		Foreground(selectedColor).
-		Bold(true).
-		BorderStyle(lipgloss.ThickBorder()).
-		BorderForeground(selectedColor)
-	delegate.Styles.SelectedDesc = delegate.Styles.SelectedDesc.
-		Foreground(textSecondaryColor).
-		Bold(true).
-		BorderStyle(lipgloss.ThickBorder()).
-		BorderForeground(selectedColor)
+	stageItemDelegate := newStageItemDelegate()
 
-	l := list.New(stageItems, delegate, width, height)
+	l := list.New(stageItems, stageItemDelegate, width, height)
 	l.Title = "STAGES"
 	l.Styles.Title = lipgloss.NewStyle().
 		Padding(0, 1).
@@ -67,9 +70,137 @@ func newStageOptionsList(stages []lolesports.Stage, width, height int) list.Mode
 	return l
 }
 
+type stageItemStyles struct {
+	list.DefaultItemStyles
+
+	DisabledTitle         lipgloss.Style
+	DisabledDesc          lipgloss.Style
+	DisabledSelectedTitle lipgloss.Style
+	DisabledSelectedDesc  lipgloss.Style
+}
+
+func newStageItemStyles() (s stageItemStyles) {
+	defaultStyles := list.NewDefaultItemStyles()
+
+	s.DefaultItemStyles = defaultStyles
+
+	// Selected
+	s.SelectedTitle = defaultStyles.SelectedTitle.
+		Foreground(selectedColor).
+		Bold(true).
+		BorderStyle(lipgloss.ThickBorder()).
+		BorderForeground(selectedColor)
+
+	s.SelectedDesc = defaultStyles.SelectedDesc.
+		Foreground(textSecondaryColor).
+		BorderStyle(lipgloss.ThickBorder()).
+		BorderForeground(selectedColor)
+
+	// Disabled but selected
+	s.DisabledSelectedTitle = defaultStyles.SelectedTitle.
+		Foreground(textDisabledColor).
+		Bold(false).
+		BorderStyle(lipgloss.ThickBorder()).
+		BorderForeground(textDisabledColor)
+
+	s.DisabledSelectedDesc = defaultStyles.SelectedDesc.
+		Foreground(textDisabledColor).
+		Bold(false).
+		BorderStyle(lipgloss.ThickBorder()).
+		BorderForeground(textDisabledColor)
+
+	// Disabled not selected
+	s.DisabledTitle = defaultStyles.NormalTitle.
+		Foreground(textDisabledColor)
+
+	s.DisabledDesc = defaultStyles.NormalDesc.
+		Foreground(textDisabledColor)
+
+	return s
+}
+
+type stageItemDelegate struct {
+	list.DefaultDelegate
+
+	Styles stageItemStyles
+}
+
+func newStageItemDelegate() stageItemDelegate {
+	return stageItemDelegate{
+		DefaultDelegate: list.NewDefaultDelegate(),
+		Styles:          newStageItemStyles(),
+	}
+}
+
+func (d stageItemDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	var (
+		title, desc string
+		isDisabled  bool
+		s           = &d.Styles
+	)
+
+	if i, ok := item.(stageItem); ok {
+		title = i.Title()
+		desc = i.Description()
+		isDisabled = i.IsDisabled()
+	} else {
+		return
+	}
+
+	if m.Width() <= 0 {
+		// short-circuit
+		return
+	}
+
+	// Prevent text from exceeding list width
+	textwidth := m.Width() - s.NormalTitle.GetPaddingLeft() - s.NormalTitle.GetPaddingRight()
+	title = ansi.Truncate(title, textwidth, "…")
+	if d.ShowDescription {
+		var lines []string
+		for i, line := range strings.Split(desc, "\n") {
+			if i >= d.Height()-1 {
+				break
+			}
+			lines = append(lines, ansi.Truncate(line, textwidth, "…"))
+		}
+		desc = strings.Join(lines, "\n")
+	}
+
+	isSelected := index == m.Index()
+
+	switch {
+	case isDisabled && isSelected:
+		title = s.DisabledSelectedTitle.Render(title)
+		desc = s.DisabledSelectedDesc.Render(desc)
+	case isDisabled && !isSelected:
+		title = s.DisabledTitle.Render(title)
+		desc = s.DisabledDesc.Render(desc)
+	case !isDisabled && isSelected:
+		title = s.SelectedTitle.Render(title)
+		desc = s.SelectedDesc.Render(desc)
+	case !isDisabled && !isSelected:
+		title = s.NormalTitle.Render(title)
+		desc = s.NormalDesc.Render(desc)
+	}
+
+	if d.ShowDescription {
+		fmt.Fprintf(w, "%s\n%s", title, desc)
+		return
+	}
+	fmt.Fprintf(w, "%s", title)
+}
+
 func getStageType(stage lolesports.Stage) stageType {
 	if len(stage.Sections) > 0 && len(stage.Sections[0].Rankings) == 0 {
 		return stageTypeBracket
 	}
 	return stageTypeGroups
+}
+
+func isStageAvailable(stage lolesports.Stage, availableStages []string) bool {
+	if getStageType(stage) == stageTypeBracket {
+		return slices.Contains(availableStages, stage.ID)
+	}
+
+	return true
 }


### PR DESCRIPTION
Implementation to prevent selecting a stage if the template is not available

- [x] Selecting a stage without template should not load the bracket
- [ ] ~~Use cache for available templates~~ -> Will do in another PR, need to extract the list fetch to another cache / module dedicated to template list
- [x] Change the display of unavailable stages (different color)
- [x] Bonus : display "Unavailable stage template" as a caption if possible